### PR TITLE
Switch to ethers.js from ethereumjs-abi

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Feel free to open PR to add new types.
 
 ## Contributing
 
-The site is powered by [CRA(Create React App)](https://reactjs.org/docs/create-a-new-react-app.html) using [React.js](https://reactjs.org/) and [ethereumjs-abi](https://github.com/ethereumjs/ethereumjs-abi).
+The site is powered by [CRA(Create React App)](https://reactjs.org/docs/create-a-new-react-app.html) using [React.js](https://reactjs.org/) and [ethers.js](https://github.com/ethers-io/ethers.js).
 
 1. Fork the repo on GitHub
 2. Clone the project to your own machine

--- a/package-lock.json
+++ b/package-lock.json
@@ -2475,14 +2475,6 @@
         "@babel/types": "^7.3.0"
       }
     },
-    "@types/bn.js": {
-      "version": "4.11.6",
-      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
-      "integrity": "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==",
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/eslint": {
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.28.0.tgz",
@@ -2496,15 +2488,6 @@
       "version": "0.0.50",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.50.tgz",
       "integrity": "sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw=="
-    },
-    "@types/ethereumjs-abi": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/@types/ethereumjs-abi/-/ethereumjs-abi-0.6.3.tgz",
-      "integrity": "sha512-DnHvqPkrJS5w4yZexTa5bdPNb8IyKPYciou0+zZCIg5fpzvGtyptTvshy0uZKzti2/k/markwjlxWRBWt7Mjuw==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
     },
     "@types/glob": {
       "version": "7.1.4",
@@ -2583,14 +2566,6 @@
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
     },
-    "@types/pbkdf2": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@types/pbkdf2/-/pbkdf2-3.1.0.tgz",
-      "integrity": "sha512-Cf63Rv7jCQ0LaL8tNXmEyqTHuIJxRdlS5vMh1mj5voN4+QFhVZnlZruezqpWYDiJ8UTzhP0VmeLXCmBk66YrMQ==",
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/prettier": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.3.2.tgz",
@@ -2657,14 +2632,6 @@
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
       "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
-    },
-    "@types/secp256k1": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@types/secp256k1/-/secp256k1-4.0.3.tgz",
-      "integrity": "sha512-Da66lEIFeIz9ltsdMZcpQvmrmmoqrfju8pm1BH8WbYjZSwUgCwXLb9C+9XYogwBITnbsSaMdVPb2ekf7TV+03w==",
-      "requires": {
-        "@types/node": "*"
-      }
     },
     "@types/source-list-map": {
       "version": "0.1.2",
@@ -3846,14 +3813,6 @@
         }
       }
     },
-    "base-x": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.8.tgz",
-      "integrity": "sha512-Rl/1AWP4J/zRrk54hhlxH4drNxPJXYUaKffODVI53/dAsV4t9fBxyxYKAVPU1XBHxYwOWP9h9H0hM2MVw4YfJA==",
-      "requires": {
-        "safe-buffer": "^5.0.1"
-      }
-    },
     "base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -3890,11 +3849,6 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "optional": true
-    },
-    "blakejs": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.1.1.tgz",
-      "integrity": "sha512-bLG6PHOCZJKNshTjGRBvET0vTciwQE6zFKOKKXPDJfwFBd4Ac0yBfPZqcGvGJap50l7ktvlpFqc2jGVaUgbJgg=="
     },
     "bluebird": {
       "version": "3.7.2",
@@ -4084,24 +4038,6 @@
         "electron-to-chromium": "^1.3.723",
         "escalade": "^3.1.1",
         "node-releases": "^1.1.71"
-      }
-    },
-    "bs58": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
-      "integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
-      "requires": {
-        "base-x": "^3.0.2"
-      }
-    },
-    "bs58check": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
-      "integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
-      "requires": {
-        "bs58": "^4.0.0",
-        "create-hash": "^1.1.0",
-        "safe-buffer": "^5.1.2"
       }
     },
     "bser": {
@@ -6501,51 +6437,6 @@
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
     },
-    "ethereum-cryptography": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
-      "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
-      "requires": {
-        "@types/pbkdf2": "^3.0.0",
-        "@types/secp256k1": "^4.0.1",
-        "blakejs": "^1.1.0",
-        "browserify-aes": "^1.2.0",
-        "bs58check": "^2.1.2",
-        "create-hash": "^1.2.0",
-        "create-hmac": "^1.1.7",
-        "hash.js": "^1.1.7",
-        "keccak": "^3.0.0",
-        "pbkdf2": "^3.0.17",
-        "randombytes": "^2.1.0",
-        "safe-buffer": "^5.1.2",
-        "scrypt-js": "^3.0.0",
-        "secp256k1": "^4.0.1",
-        "setimmediate": "^1.0.5"
-      }
-    },
-    "ethereumjs-abi": {
-      "version": "0.6.8",
-      "resolved": "https://registry.npmjs.org/ethereumjs-abi/-/ethereumjs-abi-0.6.8.tgz",
-      "integrity": "sha512-Tx0r/iXI6r+lRsdvkFDlut0N08jWMnKRZ6Gkq+Nmw75lZe4e6o3EkSnkaBP5NF6+m5PTGAr9JP43N3LyeoglsA==",
-      "requires": {
-        "bn.js": "^4.11.8",
-        "ethereumjs-util": "^6.0.0"
-      }
-    },
-    "ethereumjs-util": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
-      "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
-      "requires": {
-        "@types/bn.js": "^4.11.3",
-        "bn.js": "^4.11.0",
-        "create-hash": "^1.1.2",
-        "elliptic": "^6.5.2",
-        "ethereum-cryptography": "^0.1.3",
-        "ethjs-util": "0.1.6",
-        "rlp": "^2.2.3"
-      }
-    },
     "ethers": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.4.1.tgz",
@@ -6581,15 +6472,6 @@
         "@ethersproject/wallet": "5.4.0",
         "@ethersproject/web": "5.4.0",
         "@ethersproject/wordlists": "5.4.0"
-      }
-    },
-    "ethjs-util": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/ethjs-util/-/ethjs-util-0.1.6.tgz",
-      "integrity": "sha512-CUnVOQq7gSpDHZVVrQW8ExxUETWrnrvXYvYz55wOU8Uj4VCgw56XC2B/fVqQN+f7gmrnRHSLVnFAwsCuNwji8w==",
-      "requires": {
-        "is-hex-prefixed": "1.0.0",
-        "strip-hex-prefix": "1.0.0"
       }
     },
     "eventemitter3": {
@@ -8323,11 +8205,6 @@
         "is-extglob": "^2.1.1"
       }
     },
-    "is-hex-prefixed": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-hex-prefixed/-/is-hex-prefixed-1.0.0.tgz",
-      "integrity": "sha1-fY035q135dEnFIkTxXPggtd39VQ="
-    },
     "is-module": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
@@ -9570,15 +9447,6 @@
         "object.assign": "^4.1.2"
       }
     },
-    "keccak": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.1.tgz",
-      "integrity": "sha512-epq90L9jlFWCW7+pQa6JOnKn2Xgl2mtI664seYR6MHskvI9agt7AnDqmAlp9TqU4/caMYbA08Hi5DMZAl5zdkA==",
-      "requires": {
-        "node-addon-api": "^2.0.0",
-        "node-gyp-build": "^4.2.0"
-      }
-    },
     "killable": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/killable/-/killable-1.0.1.tgz",
@@ -10230,20 +10098,10 @@
         }
       }
     },
-    "node-addon-api": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
-      "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
-    },
     "node-forge": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
       "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA=="
-    },
-    "node-gyp-build": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
-      "integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg=="
     },
     "node-int64": {
       "version": "0.4.0",
@@ -13147,14 +13005,6 @@
         "inherits": "^2.0.1"
       }
     },
-    "rlp": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.6.tgz",
-      "integrity": "sha512-HAfAmL6SDYNWPUOJNrM500x4Thn4PZsEy5pijPh40U9WfNk0z15hUYzO9xVIMAdIHdFtD8CBDHd75Td1g36Mjg==",
-      "requires": {
-        "bn.js": "^4.11.1"
-      }
-    },
     "rollup": {
       "version": "1.32.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.32.1.tgz",
@@ -13467,16 +13317,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
       "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA=="
-    },
-    "secp256k1": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.2.tgz",
-      "integrity": "sha512-UDar4sKvWAksIlfX3xIaQReADn+WFnHvbVujpcbr+9Sf/69odMwy2MUsz5CKLQgX9nsIyrjuxL2imVyoNHa3fg==",
-      "requires": {
-        "elliptic": "^6.5.2",
-        "node-addon-api": "^2.0.0",
-        "node-gyp-build": "^4.2.0"
-      }
     },
     "select-hose": {
       "version": "2.0.0",
@@ -14278,14 +14118,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
       "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA=="
-    },
-    "strip-hex-prefix": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-hex-prefix/-/strip-hex-prefix-1.0.0.tgz",
-      "integrity": "sha1-DF8VX+8RUTczd96du1iNoFUA428=",
-      "requires": {
-        "is-hex-prefixed": "1.0.0"
-      }
     },
     "strip-indent": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "bootstrap": "^5.0.1",
     "classnames": "^2.3.1",
     "copy-to-clipboard": "^3.3.1",
-    "ethereumjs-abi": "^0.6.8",
     "ethers": "^5.3.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
@@ -50,7 +49,6 @@
     ]
   },
   "devDependencies": {
-    "@types/ethereumjs-abi": "^0.6.3",
     "@types/react-select": "^4.0.15",
     "codemirror": "^5.61.1",
     "react-codemirror2": "^7.2.1"


### PR DESCRIPTION
Two reasons:
1. Contracts with bytes input were giving a wrong encoding. For example, check the constructor encoding on this contract (https://etherscan.io/address/0x18aaa7115705e8be94bffebde57af9bfc265b998#code)

![image](https://user-images.githubusercontent.com/27727946/132137488-28a733e0-5332-4b80-bd55-3e241ecb40b6.png)

![image](https://user-images.githubusercontent.com/27727946/132137475-bab07c17-6c88-4164-a6f0-ab35199f5759.png)

2. ethereumjs-abi is deprecated and their repo recommends switching to ethers.js