### PR TITLE
Support for overloaded functions in an abi

### DIFF
--- a/src/utils/index.tsx
+++ b/src/utils/index.tsx
@@ -251,8 +251,10 @@ export const parse = (abi: string): ParsedFunctions => {
 
     functions.forEach((func) => {
         const inputs = func.inputs || [];
+        const inputTypesAsString = String(inputs.map(input => input.type))
+
         if (func.type !== 'event') {
-            const key = func.type === 'constructor' ? func.type : func.name;
+            const key = func.type === 'constructor' ? func.type : `${func.name}[${inputTypesAsString}]`;
             if (key) {
                 parsedFunctions[key] = prepareFunction(func);
             }


### PR DESCRIPTION
# Why

Functions having similar name (with different parameter types) do not show up in the functions list after parsing.
For ex. ([abi source](https://gist.github.com/charles-vj/0bfa91899bdaee048ce3575d34877171))
![image](https://user-images.githubusercontent.com/71175155/176788277-564a7532-2847-442f-bfdb-1513210d7160.png)

![image](https://user-images.githubusercontent.com/71175155/176788087-8bf83a24-f10b-44c1-b776-d3e5562caa18.png)

# How

Changed function mapping keys to also contain input types to properly differentiate functions

![image](https://user-images.githubusercontent.com/71175155/176788675-1b82a7ad-b0dc-4e33-a680-ddde61423539.png)

